### PR TITLE
Add search and sort functionality to Books index

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,7 +1,23 @@
 class BooksController < ApplicationController
   def index
     @q = Book.ransack(params[:q])
-    @books = @q.result(distinct: true).includes(:tags).order(:title)
+    @sort = params[:sort].presence_in(%w[title_asc title_desc read_on_desc read_on_asc published_on_desc published_on_asc]) || "read_on_desc"
+
+    books = @q.result(distinct: true).includes(:tags)
+    @books = case @sort
+    when "title_asc"
+      books.order(title: :asc)
+    when "title_desc"
+      books.order(title: :desc)
+    when "read_on_desc"
+      books.order(read_on: :desc)
+    when "read_on_asc"
+      books.order(read_on: :asc)
+    when "published_on_desc"
+      books.order(published_on: :desc)
+    when "published_on_asc"
+      books.order(published_on: :asc)
+    end
   end
 
   def show

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,7 +1,17 @@
 <section class="card p-8">
-  <h1 class="text-3xl font-extrabold">Books</h1>
+  <div class="flex items-end justify-between mb-6">
+    <h1 class="text-3xl font-extrabold">Books</h1>
+
+    <div class="flex gap-2">
+      <%= link_to "読了日（新）", books_path(sort: "read_on_desc", q: params[:q]), class: "pill #{@sort == 'read_on_desc' ? 'bg-sky-500 text-white' : ''}" %>
+      <%= link_to "読了日（古）", books_path(sort: "read_on_asc", q: params[:q]), class: "pill #{@sort == 'read_on_asc' ? 'bg-sky-500 text-white' : ''}" %>
+      <%= link_to "タイトル（昇順）", books_path(sort: "title_asc", q: params[:q]), class: "pill #{@sort == 'title_asc' ? 'bg-sky-500 text-white' : ''}" %>
+      <%= link_to "タイトル（降順）", books_path(sort: "title_desc", q: params[:q]), class: "pill #{@sort == 'title_desc' ? 'bg-sky-500 text-white' : ''}" %>
+    </div>
+  </div>
 
   <%= search_form_for @q, url: books_path, method: :get do |f| %>
+    <%= hidden_field_tag :sort, @sort %>
     <div class="mt-4 flex gap-3">
       <%= f.search_field :title_or_authors_or_summary_cont, placeholder: "本を検索", class: "input" %>
       <%= f.submit "検索", class: "btn" %>

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class BooksControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get books_url
+    assert_response :success
+    assert_select "h1", "Books"
+  end
+
+  test "should get show" do
+    book = books(:ruby_book)
+    get book_url(book)
+    assert_response :success
+    assert_select "h1", book.title
+  end
+
+  test "index should sort by read_on desc by default" do
+    get books_url
+    assert_response :success
+
+    books = assigns(:books).to_a
+    assert_equal books(:rails_book), books[0]
+    assert_equal books(:ruby_book), books[1]
+    assert_equal books(:javascript_book), books[2]
+  end
+
+  test "index should sort by read_on asc" do
+    get books_url(sort: "read_on_asc")
+    assert_response :success
+
+    books = assigns(:books).to_a
+    assert_equal books(:javascript_book), books[0]
+    assert_equal books(:ruby_book), books[1]
+    assert_equal books(:rails_book), books[2]
+  end
+
+  test "index should sort by title asc" do
+    get books_url(sort: "title_asc")
+    assert_response :success
+
+    books = assigns(:books).to_a
+    assert_equal books(:javascript_book), books[0]
+    assert_equal books(:ruby_book), books[1]
+    assert_equal books(:rails_book), books[2]
+  end
+
+  test "index should sort by title desc" do
+    get books_url(sort: "title_desc")
+    assert_response :success
+
+    books = assigns(:books).to_a
+    assert_equal books(:rails_book), books[0]
+    assert_equal books(:ruby_book), books[1]
+    assert_equal books(:javascript_book), books[2]
+  end
+
+  test "index should search by title" do
+    get books_url(q: { title_or_authors_or_summary_cont: "Ruby" })
+    assert_response :success
+
+    books = assigns(:books)
+    assert_includes books, books(:ruby_book)
+    assert_includes books, books(:rails_book)
+    assert_not_includes books, books(:javascript_book)
+  end
+
+  test "index should search by authors" do
+    get books_url(q: { title_or_authors_or_summary_cont: "伊藤淳一" })
+    assert_response :success
+
+    books = assigns(:books)
+    assert_includes books, books(:ruby_book)
+    assert_not_includes books, books(:rails_book)
+    assert_not_includes books, books(:javascript_book)
+  end
+end

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -1,21 +1,28 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  title: MyString
-  authors: MyString
-  publisher: MyString
-  read_on: 2026-01-09
-  published_on: 2026-01-09
-  isbn: MyString
-  google_books_id: MyString
-  summary: MyText
+ruby_book:
+  title: "プロを目指す人のためのRuby入門"
+  authors: "伊藤淳一"
+  publisher: "技術評論社"
+  read_on: 2025-12-01
+  published_on: 2017-11-25
+  isbn: "9784774193274"
+  summary: "Rubyの基礎から実践まで学べる入門書"
 
-two:
-  title: MyString
-  authors: MyString
-  publisher: MyString
-  read_on: 2026-01-09
-  published_on: 2026-01-09
-  isbn: MyString
-  google_books_id: MyString
-  summary: MyText
+rails_book:
+  title: "現場で使える Ruby on Rails 5速習実践ガイド"
+  authors: "大場寧子"
+  publisher: "マイナビ出版"
+  read_on: 2026-01-15
+  published_on: 2018-10-19
+  isbn: "9784839962227"
+  summary: "Rails 5の実践的な開発手法を学べる"
+
+javascript_book:
+  title: "JavaScript本格入門"
+  authors: "山田祥寛"
+  publisher: "技術評論社"
+  read_on: 2025-11-20
+  published_on: 2016-09-30
+  isbn: "9784774184227"
+  summary: "JavaScriptの基礎から応用まで"


### PR DESCRIPTION
## 概要
- [x] Books 一覧ページに 並び替え機能 を追加
  - [x] 読了日（read_on）順（降順 / 昇順）
  - [x] 書籍名（title）順（昇順 / 降順）
  - [x] 出版日（published_on）順（降順 / 昇順）
- [x] デフォルトの並び順：読了日の降順（最近読んだ本が先頭）
- [x] 並び替え変更時も 検索クエリを保持
- [x] コントローラのテストを充実

## テスト計画
- [x]  /books にアクセスし、デフォルトで 読了日降順 になっていることを確認
 - [x] 並び替えボタンをクリックし、正しく並び替えられることを確認
 - [x] 検索後に並び替えを変更しても、検索条件が保持されていることを確認

## テスト実行
```
bundle exec rails test test/controllers/books_controller_test.rb
```

 すべてのテストがパスすることを確認

## 変更内容（Changes）
- [x] BooksController#index に並び替えロジックを追加
- [x] books/index.html.erb に並び替え用 UI を追加
- [x] books_controller_test.rb を作成（テスト 8 件）
- [x] より現実的なテストデータになるよう books の fixtures を更新