### PR TITLE
Enhance Books show page with improved layout

### DIFF
--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-3xl font-extrabold"><%= @book.title %></h1>
 
   <% if @book.authors.present? %>
-    <p class="mt-2 text-lg text-slate-600 dark:text-slate-300"><%= @book.authors %></p>
+    <p class="mt-2 text-lg font-semibold text-slate-600 dark:text-slate-300"><%= @book.authors %></p>
   <% end %>
 
   <div class="mt-3 flex flex-wrap gap-2">
@@ -13,36 +13,60 @@
     <% end %>
   </div>
 
-  <div class="mt-4 space-y-2 text-sm font-semibold">
-    <div class="inline-block rounded-lg bg-slate-200 px-3 py-2 dark:bg-slate-800">
-      読了日：<%= @book.read_on %>
+  <div class="mt-6 grid gap-4 sm:grid-cols-2">
+    <div>
+      <% if @book.image.attached? %>
+        <%= image_tag @book.image, class: "w-full rounded-2xl object-cover", alt: @book.title %>
+      <% else %>
+        <div class="aspect-[3/4] rounded-2xl bg-slate-200 grid place-items-center text-xl font-extrabold dark:bg-slate-800">
+          表紙画像
+        </div>
+      <% end %>
     </div>
-    <% if @book.published_on.present? %>
-      <div class="inline-block rounded-lg bg-slate-200 px-3 py-2 dark:bg-slate-800">
-        出版日：<%= @book.published_on %>
-      </div>
-    <% end %>
-    <% if @book.publisher.present? %>
-      <div class="inline-block rounded-lg bg-slate-200 px-3 py-2 dark:bg-slate-800">
-        出版社：<%= @book.publisher %>
-      </div>
-    <% end %>
-  </div>
 
-  <div class="mt-6 h-64 rounded-2xl bg-slate-200 grid place-items-center text-2xl font-extrabold dark:bg-slate-800">
-    表紙画像
+    <div class="space-y-4">
+      <div class="rounded-xl bg-sky-100 px-4 py-3 dark:bg-sky-900">
+        <div class="text-sm font-semibold text-slate-600 dark:text-slate-300">読了日</div>
+        <div class="mt-1 text-2xl font-extrabold text-sky-700 dark:text-sky-300">
+          <%= @book.read_on.strftime("%Y年%m月%d日") %>
+        </div>
+      </div>
+
+      <div class="space-y-2 text-sm">
+        <% if @book.published_on.present? %>
+          <div class="rounded-lg bg-slate-100 px-3 py-2 dark:bg-slate-900">
+            <span class="font-semibold">出版日：</span>
+            <%= @book.published_on.strftime("%Y年%m月%d日") %>
+          </div>
+        <% end %>
+
+        <% if @book.publisher.present? %>
+          <div class="rounded-lg bg-slate-100 px-3 py-2 dark:bg-slate-900">
+            <span class="font-semibold">出版社：</span>
+            <%= @book.publisher %>
+          </div>
+        <% end %>
+
+        <% if @book.isbn.present? %>
+          <div class="rounded-lg bg-slate-100 px-3 py-2 dark:bg-slate-900">
+            <span class="font-semibold">ISBN：</span>
+            <%= @book.isbn %>
+          </div>
+        <% end %>
+      </div>
+    </div>
   </div>
 
   <% if @book.summary.present? %>
-    <div class="mt-8 rounded-xl bg-slate-100 px-4 py-3 dark:bg-slate-900">
-      <div class="text-center font-extrabold">概要</div>
-      <div class="mt-2 text-sm text-slate-700 dark:text-slate-200 whitespace-pre-wrap">
+    <div class="mt-8 rounded-xl bg-slate-100 px-5 py-4 dark:bg-slate-900">
+      <div class="text-lg font-extrabold text-center mb-3">概要・メモ</div>
+      <div class="text-sm text-slate-700 dark:text-slate-200 whitespace-pre-wrap leading-relaxed">
         <%= @book.summary %>
       </div>
     </div>
   <% end %>
 
   <div class="mt-8">
-    <%= link_to "← Book一覧へ", books_path, class: "hover:underline text-sm" %>
+    <%= link_to "← Book一覧へ", books_path, class: "hover:underline text-sm font-semibold" %>
   </div>
 </section>

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -14,6 +14,63 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", book.title
   end
 
+  test "show should display book title" do
+    book = books(:ruby_book)
+    get book_url(book)
+    assert_response :success
+    assert_select "h1", text: book.title
+  end
+
+  test "show should display authors" do
+    book = books(:ruby_book)
+    get book_url(book)
+    assert_response :success
+    assert_select "p", text: /#{book.authors}/
+  end
+
+  test "show should display read_on date" do
+    book = books(:ruby_book)
+    get book_url(book)
+    assert_response :success
+    assert_select "div", text: /読了日/
+    assert_select "div", text: /#{book.read_on.strftime("%Y年%m月%d日")}/
+  end
+
+  test "show should display publisher when present" do
+    book = books(:ruby_book)
+    get book_url(book)
+    assert_response :success
+    assert_select "div", text: /出版社/
+    assert_select "div", text: /#{book.publisher}/
+  end
+
+  test "show should display isbn when present" do
+    book = books(:ruby_book)
+    get book_url(book)
+    assert_response :success
+    assert_select "div", text: /ISBN/
+    assert_select "div", text: /#{book.isbn}/
+  end
+
+  test "show should display summary when present" do
+    book = books(:ruby_book)
+    get book_url(book)
+    assert_response :success
+    assert_select "div", text: /概要・メモ/
+    assert_select "div", text: /#{book.summary}/
+  end
+
+  test "show should display tags" do
+    book = books(:ruby_book)
+    # タグを追加
+    tag = Tag.create!(name: "Ruby", kind: :book)
+    book.tags << tag
+
+    get book_url(book)
+    assert_response :success
+    assert_select "span", text: tag.name
+  end
+
   test "index should sort by read_on desc by default" do
     get books_url
     assert_response :success


### PR DESCRIPTION
## 概要
- [x] Books 詳細ページを 2カラムレイアウト に再設計
- [x] 読了日（read_on）を強調表示
- [x] 書籍カバー画像 を表示（Active Storage 使用）
- [x] ISBN 情報 を表示
- [x] 概要／メモ欄 を見やすく改善
- [x] 詳細ページ向けの 包括的なテストを追加

## 変更内容（Changes）
ビューの改善：
- [x] 2カラムレイアウト
- [x] 左側に書籍カバー画像、右側に書籍の詳細情報を表示
- [x] 読了日の強調表示
- [x] 青い背景で大きく、目立つ形で表示
- [x] 画像対応
- [x] Active Storage 経由で書籍カバーを表示（未設定の場合はプレースホルダーを表示）
- [x] 日付フォーマット改善
- [x] 日本語表記（YYYY年MM月DD日）を使用
- [x] ISBN 表示
- [x] ISBN がある場合に表示
- [x] 概要／メモの改善
- [x] タイポグラフィや余白を調整し、読みやすく改善

## テスト
- [x] 詳細ページ用に 7 件のテストを追加：
- [x] タイトルが表示されること
- [x] 著者が表示されること
- [x] 読了日が表示されること
- [x] 出版社が表示されること
- [x] ISBN が表示されること
- [x] 概要／メモが表示されること
- [x] タグが表示されること

## テスト計画（Test plan）
 - [x] /books/:id にアクセスし、新しいレイアウトが適用されていることを確認
 - [x] 読了日が目立つ形で表示されていることを確認
 - [x] すべての書籍情報が正しく表示されていることを確認
 - [x] 書籍カバー画像をアップロードし、正しく表示されることを確認

## テストを実行
```
bundle exec rails test test/controllers/books_controller_test.rb
```

 - [x] 全 15 件のテストがパスすることを確認