### PR TITLE
Books import時にタグ選択UIを追加

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -28,6 +28,7 @@ class BooksController < ApplicationController
   def search
     @query = params[:query]
     @results = []
+    @book_tags = Tag.for_books
 
     if @query.present?
       client = GoogleBooksClient.new
@@ -53,9 +54,16 @@ class BooksController < ApplicationController
     end
 
     if @book.save
+      # タグを関連付け
+      if book_data[:tag_ids].present?
+        tag_ids = book_data[:tag_ids].reject(&:blank?)
+        @book.tags = Tag.where(id: tag_ids)
+      end
+
       redirect_to book_path(@book), notice: "書籍を登録しました"
     else
       @query = params[:query]
+      @book_tags = Tag.for_books
       client = GoogleBooksClient.new
       @results = client.search(@query) if @query.present?
       render :search, status: :unprocessable_entity

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -67,8 +67,8 @@
                 <% end %>
               </div>
 
-              <!-- 登録ボタン -->
-              <div class="flex items-start">
+              <!-- タグ選択 & 登録ボタン -->
+              <div class="flex flex-col gap-3">
                 <%= form_with url: create_from_google_books_books_path, method: :post, local: true do |f| %>
                   <%= hidden_field_tag "book_data[title]", result[:title] %>
                   <%= hidden_field_tag "book_data[authors]", result[:authors] %>
@@ -78,6 +78,18 @@
                   <%= hidden_field_tag "book_data[description]", result[:description] %>
                   <%= hidden_field_tag "book_data[thumbnail_url]", result[:thumbnail_url] %>
                   <%= hidden_field_tag :query, @query %>
+
+                  <% if @book_tags.any? %>
+                    <div class="flex flex-wrap gap-2">
+                      <% @book_tags.each do |tag| %>
+                        <label class="pill flex items-center gap-1 cursor-pointer">
+                          <%= check_box_tag "book_data[tag_ids][]", tag.id, false, id: "tag_#{result[:isbn]}_#{tag.id}" %>
+                          <%= tag.name %>
+                        </label>
+                      <% end %>
+                    </div>
+                  <% end %>
+
                   <%= f.submit "登録", class: "btn bg-sky-500 text-white hover:bg-sky-600" %>
                 <% end %>
               </div>


### PR DESCRIPTION
## Summary
- Google Books検索画面にタグ選択チェックボックスを追加
- 書籍登録時に選択したタグを保存する機能を実装
- タグ選択・保存のコントローラテストを追加

## 変更内容
- `app/controllers/books_controller.rb`: searchアクションでタグ読み込み、create_from_google_booksでタグ保存
- `app/views/books/search.html.erb`: タグチェックボックスUI追加
- `test/controllers/books_controller_test.rb`: タグ関連テスト追加

## Test plan
- [ ] Google Books検索画面でタグチェックボックスが表示される
- [ ] 書籍登録時にタグを選択して保存できる
- [ ] 複数タグを同時に選択できる
- [ ] CIテストが通過する

🤖 Generated with [Claude Code](https://claude.com/claude-code)