### PR TITLE
Active StorageとCloudinaryの連携を修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,4 @@ gem "sassc-rails"
 
 # Cloudinary for image storage
 gem "cloudinary"
+gem "activestorage-cloudinary-service"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       activerecord (= 8.1.1)
       activesupport (= 8.1.1)
       marcel (~> 1.0)
+    activestorage-cloudinary-service (0.2.3)
     activesupport (8.1.1)
       base64
       bigdecimal
@@ -466,6 +467,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  activestorage-cloudinary-service
   bootsnap
   brakeman
   bundler-audit


### PR DESCRIPTION
## 概要
画像アップロード時に500エラーが発生していた問題を修正しました。

## 原因
`cloudinary` gemだけではActive Storageとの連携が不完全でした。

## 修正内容
- `activestorage-cloudinary-service` gemを追加

## テスト方法
- [ ] admin画面でBook/Article/Appに画像付きで新規登録
- [ ] 登録後、画像が正常に表示されることを確認
